### PR TITLE
Tem/convergent crossmapping

### DIFF
--- a/src/CrossMappings.jl
+++ b/src/CrossMappings.jl
@@ -7,6 +7,7 @@ using StateSpaceReconstruction
 using Statistics
 using StatsBase
 
+include("convergent_cross_mapping/crossmapping.jl")
 include("convergent_cross_mapping/convergentcrossmapping.jl")
 
 end # module

--- a/src/convergent_cross_mapping/convergentcrossmapping.jl
+++ b/src/convergent_cross_mapping/convergentcrossmapping.jl
@@ -337,3 +337,8 @@ function convergentcrossmap(driver,
             kwargs...)
     end
 end
+
+export
+ccm,
+ccm_with_summary,
+convergentcrossmap

--- a/src/convergent_cross_mapping/convergentcrossmapping.jl
+++ b/src/convergent_cross_mapping/convergentcrossmapping.jl
@@ -1,5 +1,6 @@
 include("validate_input.jl")
 
+
 """
     ccm_with_summary(driver,
             response,
@@ -123,6 +124,7 @@ function ccm_with_summary(driver,
                 uncertainties[i] = std(correlations)
             end
         end
+
         if average_measure == :none
             return uncertainties
         elseif uncertainty_measure == :none
@@ -219,6 +221,7 @@ function ccm(driver,
     [crossmap(driver[1:ts_len], response[1:ts_len]; kwargs...)
             for ts_len in timeseries_lengths]
 end
+
 
 """
     convergentcrossmap(driver,
@@ -329,6 +332,9 @@ function convergentcrossmap(driver,
         ccm_with_summary(driver,
             response,
             timeseries_lengths;
+            average_measure = average_measure,
+            uncertainty_measure = uncertainty_measure,
+            quantiles = quantiles,
             kwargs...)
     else
         ccm(driver,
@@ -336,9 +342,11 @@ function convergentcrossmap(driver,
             timeseries_lengths;
             kwargs...)
     end
+
 end
 
+
 export
-ccm,
 ccm_with_summary,
+ccm,
 convergentcrossmap

--- a/src/convergent_cross_mapping/convergentcrossmapping.jl
+++ b/src/convergent_cross_mapping/convergentcrossmapping.jl
@@ -1,137 +1,32 @@
-using StateSpaceReconstruction
 include("validate_input.jl")
 
 """
-    predict_point!(predictions, i, driver_values, u, w, dists, dim)
-
-The prediction part of the convergent cross mapping algorithm.
-
-## Algorithm
-
-Consider the point in the delay embedding of `response` point with
-time index `i`. Denote the time indices of its nearest
-neighbors ``t_1, t_2, \\ldots, t_{dim+1}``. Denote the scalar values
-of `driver` at those time indices ``y_1, y_2, \\ldots, y_{dim+1}``.
-
-Given `distances` ``d_1, d_2, \\ldots, d_{dim+1}`` from the `i`-th
-point to its nearest neighbors, we compute the weights `w` from
-the cross mapping algorithm ([Sugihara et al, 2012; supplementary
-material, page 4](http://science.sciencemag.org/content/sci/suppl/2012/09/19/science.1227079.DC1/Sugihara.SM.pdf)). The weights `w` and coefficients `u` are stored in
-pre-allocated vectors.
-
-A prediction for the observation with time index `i` in the `driver`
-timeseries, call it ``\\hat{y}(i)``, is computed as the sum
-
-```math
-\\hat{y}(i) = \\sum_{j=1}^{dim+1} w_j y_j.
-```
-
-We store the prediction ``\\hat{y}(i)`` in position `i` of the pre-allocated vector
-`predictions`.
-
-
-## Arguments
-- **`predictions`**: A pre-allocated vector in which to store the
-    prediction for the scalar value of the `driver` series.
-- **`i`**: The time index of the point of the `driver` series being
-    predicted. The prediction is stored in `predictions[i]`.
-- **`driver_values`**: Let ``t_1, t_2, \\ldots, t_{dim + 1}`` be
-    the time indices of
-    the nearest neighbors to the delay embedding point with time
-    index `i`. `driver_values` contains the scalar values of the
-    `driver` series at those time indices.
-- **`u`**: A pre-allocated vector of length `dim + 1` that holds the
-    normalisation coefficients for computing the weights in the
-    cross mapping algorithm.
-- **`w`**: A pre-allocated vector of length `dim + 1` that holds
-    the computed weights for the cross mapping algorithm.
-- **`dists`**: The distances from delay embedding point with time index
-    `i` to its `dim + 1` nearest neighbors, in order of increasing
-    distances.
-- **`dim`**: The dimension of the delay embedding.
-
-## References
-Sugihara, George, et al. "Detecting causality in complex ecosystems."
-Science (2012): 1227079.
-[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
-
-"""
-function predict_point!(predictions, i, driver_values, u, w, distances, dim)
-    if distances[1] == 0
-        @warn "The first distance is zero. Will yield division by zero"
-    end
-    for j in 1:(dim + 1)
-        u[j] = exp(-(distances[j]/distances[1]))
-    end
-    # The `predictions` vector is pre-allocated and `predictions[i]` may
-    # have a nonzero value if it has been visited in a previous iteration.
-    # Reset, so that we are always starting the prediction from zero.
-    predictions[i] = 0.0
-    for j in 1:(dim + 1)
-        #w[j] = u[j] / sum(u)
-        predictions[i] =+ sum((u[j] / sum(u)) .* driver_values)
-    end
-end
-
-
-function find_nearest!(nearest_idxs, nearest_dists, i, idxs, dists, dim, exclusion_radius)
-    if (2 * exclusion_radius + 2 + dim) > length(idxs[1])
-       throw(DomainError(exclusion_radius, "Too few points can be selected from `idxs=$idxs` with `dim=$dim` and `exclusion_radius=$exclusion_radius`."))
-    end
-
-    N = length(nearest_idxs)
-
-    for k = 1:N
-        # If exclusion_radius == 0, then skip the first
-        # point, because it is the distance to itself.
-        if exclusion_radius == 0
-            for j = 1:(dim + 1)
-                nearest_idxs[k][j] = idxs[k][j + 1]
-                nearest_dists[k][j] = dists[k][j + 1]
-            end
-        # Otherwise, find the nearest neighbors outside
-        # the temporal exclusion radius.
-        else
-            points_found = 0
-            # assume we have already checked a point, so that
-            # we skip the first neighbor (which is the point
-            # itself).
-            points_tried = 1
-            while points_found < (dim + 1)
-                if (idxs[k][points_tried + 1] < (i - exclusion_radius) ||
-                    idxs[k][points_tried + 1] > (i + exclusion_radius))
-                    nearest_idxs[k][points_found + 1] = idxs[k][points_tried + 1]
-                    nearest_dists[k][points_found + 1] = dists[k][points_tried + 1]
-                    points_found += 1
-                end
-                points_tried += 1
-            end
-        end
-    end
-end
-
-
-"""
-    crossmap(driver, response;
-        dim::Int = 3,
-        τ::Int = 1,
-        libsize::Int = 10,
-        replace::Bool = false,
-        n_reps::Int = 100,
-        surr_func::Function = randomshuffle,
-        which_is_surr::Symbol = :none,
-        exclusion_radius::Int = 0,
-        tree_type = NearestNeighbors.KDTree,
-        distance_metric = Distances.Euclidean(),
-        correspondence_measure = StatsBase.cor,
-        ν::Int = 0)
+    ccm_with_summary(driver,
+            response,
+            timeseries_lengths;
+            average_measure::Symbol = :median,
+            uncertainty_measure::Symbol = :quantile,
+            quantiles = [0.327, 0.673],
+            kwargs...)
 
 ## Algorithm
-Compute the cross mapping between a `driver` series and a `response` series.
+Compute the cross mapping between a `driver` series and a `response` series over
+different `timeseries_lengths` and return summary statistics of the results.
 
 ## Arguments
 - **`driver`**: The data series representing the putative driver process.
 - **`response`**: The data series representing the putative response process.
+- **`timeseries_lengths`**: Time series length(s) for which to compute the
+    cross mapping(s).
+
+## Summary keyword arguments
+- **`average_measure`**: Either `:median` or `:mean`. Default is `:median`.
+- **`uncertainty_measure`**: Either `:quantile` or `:std`. Default is `:quantile`.
+- **`quantiles`**: Compute uncertainty over quantile(s) if `uncertainty_measure`
+    is `:quantile`. Default is `[0.327, 0.673]`, roughly corresponding to 1s for
+    normally distributed data.
+
+## Keyword arguments to `crossmap`
 - **`dim`**: The dimension of the state space reconstruction (delay embedding)
     constructed from the `response` series. Default is `dim = 3`.
 - **`τ`**: The embedding lag for the delay embedding constructed from `response`.
@@ -193,96 +88,252 @@ Ye, Hao, et al. "Distinguishing time-delayed causal interactions using convergen
 Ye, H., et al. "rEDM: Applications of empirical dynamic modeling from time series." R Package Version 0.4 7 (2016).
 [https://cran.r-project.org/web/packages/rEDM/index.html](https://cran.r-project.org/web/packages/rEDM/index.html)
 """
-function crossmap(driver, response;
-            dim::Int = 3,
-            τ::Int = 1,
-            ν::Int = 0,
-            libsize::Int = length(driver) - dim*τ - abs(ν),
-            n_reps::Int = 100,
-            replace::Bool = true,
-            exclusion_radius::Int = 0,
-            jitter::Float64 = 1e-3,
-            which_is_surr::Symbol = :none,
-            surr_func::Function = randomshuffle,
-            tree_type = NearestNeighbors.KDTree,
-            distance_metric = Distances.Euclidean(),
-            correspondence_measure = StatsBase.cor)
+function ccm_with_summary(driver,
+            response,
+            timeseries_lengths;
+            average_measure::Symbol = :median,
+            uncertainty_measure::Symbol = :quantile,
+            quantiles = [0.327, 0.673],
+            kwargs...)
 
-    points_available = length(response) - dim*τ
-    validate_exclusion_radius!(exclusion_radius, points_available)
-    validate_embedding_params(dim, τ, points_available)
-    validate_surr(which_is_surr, surr_func)
-    validate_libsize(libsize, driver, dim, τ, ν, replace)
+    if average_measure ∈ [:median, :mean]
+            average = zeros(Float64, length(timeseries_lengths))
+        end
 
-    if which_is_surr == :response
-        response = surr_func(response)
-    elseif which_is_surr == :driver
-        driver = surr_func(driver)
-    elseif which_is_surr == :both
-        driver = surr_func(driver)
-        response = surr_func(response)
-    end
+        if uncertainty_measure == :quantile
+            uncertainties = zeros(Float64, length(timeseries_lengths), length(quantiles))
+        elseif uncertainty_measure == :std
+            uncertainties = zeros(Float64, length(timeseries_lengths))
+        end
 
-    ######################################################################
-    # Embedding and the nearest neighbor search.
-    # ----------------------------------------------------------
-    # All searches are done before the cross mapping repetitions,
-    # because this is computationally cheaper for all but the
-    # smallest library sizes and number of repetitions.
-    ######################################################################
-    embedding_lags = collect(1:-τ:-(τ*dim - 1))
-    embedding = StateSpaceReconstruction.Embeddings.embed([response], [1 for i in 1:dim], embedding_lags).points
-    n_embedding_pts = size(embedding, 2)
+        for (i, ts_len) in enumerate(timeseries_lengths)
+            correlations = crossmap(driver[1:ts_len], response[1:ts_len]; kwargs...)
 
-    validate_embedding!(embedding, jitter)
-    tree = tree_type(embedding, distance_metric)
+            if average_measure == :mean
+                average[i] = mean(correlations)
+            elseif average_measure == :median
+                average[i] = median(correlations)
+            end
 
-    idxs, dists = knn(tree, embedding, dim + 2 + 2*exclusion_radius + 1, true)
-    nearest_idxs = [zeros(Int32, dim + 1) for i = 1:n_embedding_pts]
-    nearest_dists = [zeros(Float64, dim + 1) for i = 1:n_embedding_pts]
-
-    for i in 1:n_embedding_pts
-        find_nearest!(nearest_idxs, nearest_dists, i, idxs, dists, dim, exclusion_radius)
-    end
-
-    ######################################################################
-    # Cross mapping
-    ######################################################################
-    # Pre-allocate vectors to hold weights and coefficients, as well as
-    # the predictions, for the prediction part of the algorithm.
-    u = Vector{Float64}(undef, dim + 1)
-    w = Vector{Float64}(undef, dim + 1)
-    predictions =  zeros(Float64, libsize)
-
-    # Pre-allocate vector to hold the time indices of the library points
-    # we select at each cross map repetition (it is from these points
-    # predictions are made).
-    point_idxs = zeros(Int32, libsize)
-
-    # Pre-allocate vector to hold the correspondences between actual
-    # and predicted values of the driver time series.
-    correspondence = zeros(Float64, n_reps)
-
-    for k in 1:n_reps
-        if ν >= 0
-            sample!((1 + ν):n_embedding_pts, point_idxs, replace = replace)
+            if uncertainty_measure == :quantile
+                for (j, quant) in enumerate(quantiles)
+                    uncertainties[i, j] = quantile(correlations, quant)
+                end
+            elseif uncertainty_measure == :std
+                uncertainties[i] = std(correlations)
+            end
+        end
+        if average_measure == :none
+            return uncertainties
+        elseif uncertainty_measure == :none
+            return average
         else
-            sample!(1:(n_embedding_pts - abs(ν)), point_idxs, replace = replace)
+            return average, uncertainties
         end
-
-        # For every point selected at this repetition, make a prediction.
-        @inbounds for i in 1:length(point_idxs)
-            idx = point_idxs[i]
-            predict_point!(predictions, i, driver[nearest_idxs[idx]], u, w, nearest_dists[idx], dim)
-        end
-
-        correspondence[k] = correspondence_measure(predictions, driver[point_idxs .- ν])
-    end
-
-    return correspondence
 end
 
-export
-predict_point!,
-find_nearest!,
-crossmap
+
+"""
+    ccm(driver,
+            response,
+            timeseries_lengths;
+            kwargs...) -> Vector{Vector{Float64}}
+
+## Algorithm
+Compute the cross mapping between a `driver` series and a `response` series over
+different `timeseries_lengths`.
+
+## Arguments
+- **`driver`**: The data series representing the putative driver process.
+- **`response`**: The data series representing the putative response process.
+- **`timeseries_lengths`**: Time series length(s) for which to compute the
+    cross mapping(s).
+
+## Keyword arguments to `crossmap`
+- **`dim`**: The dimension of the state space reconstruction (delay embedding)
+    constructed from the `response` series. Default is `dim = 3`.
+- **`τ`**: The embedding lag for the delay embedding constructed from `response`.
+    Default is `τ = 1`.
+- **`ν`**: The prediction lag to use when predicting scalar values of `driver`
+    fromthe delay embedding of `response`.
+    `ν > 0` are forward lags (causal; `driver`'s past influences `response`'s future),
+    and `ν < 0` are backwards lags (non-causal; `driver`'s' future influences
+    `response`'s past). Adjust the prediction lag if you
+    want to performed lagged ccm
+    [(Ye et al., 2015)](https://www.nature.com/articles/srep14750).
+    Default is `ν = 0`, as in
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079).
+    *Note: The sign of the lag `ν` is organized to conform with the conventions in
+    [TransferEntropy.jl](), and is opposite to the convention used in the
+    [`rEDM`](https://cran.r-project.org/web/packages/rEDM/index.html) package
+    ([Ye et al., 2016](https://cran.r-project.org/web/packages/rEDM/index.html)).*
+- **`libsize`**: Among how many delay embedding points should we sample time indices
+    and look for nearest neighbours at each cross mapping realization (of which there
+    are `n_reps`)?
+- **`n_reps`**: The number of times we draw a library of `libsize` points from the
+    delay embedding of `response` and try to predict `driver` values. Equivalently,
+    how many times do we cross map for this value of `libsize`?
+    Default is `n_reps = 100`.
+- **`replace`**: Sample delay embedding points with replacement? Default is `replace = true`.
+- **`exclusion_radius`**: How many temporal neighbors of the delay embedding
+    point `response_embedding(t)` to exclude when searching for neighbors to
+    determine weights for predicting the scalar point `driver(t + ν)`.
+    Default is `exclusion_radius = 0`.
+- **`which_is_surr`**: Which data series should be replaced by a surrogate
+    realization of the type given by `surr_type`? Must be one of the
+    following: `:response`, `:driver`, `:none`, `:both`.
+    Default is `:none`.
+- **`surr_func`**: A valid surrogate function from TimeseriesSurrogates.jl.
+- **`tree_type`**: The type of tree to build when looking for nearest neighbors.
+    Must be a tree type from NearestNeighbors.jl. For now, this is either
+    `BruteTree`, `KDTree` or `BallTree`.
+- **`distance_metric`**: An instance of a `Metric` from Distances.jl. `BallTree` and `BruteTree` work with any `Metric`.
+    `KDTree` only works with the axis aligned metrics `Euclidean`, `Chebyshev`,
+    `Minkowski` and `Cityblock`. Default is `metric = Euclidean()` *(note the instantiation of the metric)*.
+- **`correspondence_measure`**: The function that computes the correspondence
+    between actual values of `driver` and predicted values. Can be any
+    function returning a similarity measure between two vectors of values.
+    Default is `correspondence_measure = StatsBase.cor`, which returns values on ``[-1, 1]``.
+    In this case, any negative values are usually filtered out (interpreted as zero coupling) and
+    a value of ``1`` means perfect prediction.
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+    also proposes to use the root mean square deviation, for which a value of ``0`` would
+    be perfect prediction.
+
+## References
+Sugihara, George, et al. "Detecting causality in complex ecosystems."
+Science (2012): 1227079.
+[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+
+Ye, Hao, et al. "Distinguishing time-delayed causal interactions using convergent cross mapping." Scientific Reports 5 (2015): 14750.
+[https://www.nature.com/articles/srep14750](https://www.nature.com/articles/srep14750)
+
+Ye, H., et al. "rEDM: Applications of empirical dynamic modeling from time series." R Package Version 0.4 7 (2016).
+[https://cran.r-project.org/web/packages/rEDM/index.html](https://cran.r-project.org/web/packages/rEDM/index.html)
+"""
+function ccm(driver,
+            response,
+            timeseries_lengths;
+            kwargs...)
+
+    [crossmap(driver[1:ts_len], response[1:ts_len]; kwargs...)
+            for ts_len in timeseries_lengths]
+end
+
+"""
+    convergentcrossmap(driver,
+            response,
+            timeseries_lengths;
+            summarise::Bool = true,
+            average_measure::Symbol = :median,
+            uncertainty_measure::Symbol = :quantile,
+            quantiles = [0.327, 0.673],
+            kwargs...)
+
+## Algorithm
+Compute the cross mapping between a `driver` series and a `response` series over
+different `timeseries_lengths`. If `summarise = true`, then call `ccm_with_summary`.
+If `summarise = false`, then call `ccm` (returns raw crossmap skills).
+
+## Arguments
+- **`driver`**: The data series representing the putative driver process.
+- **`response`**: The data series representing the putative response process.
+- **`timeseries_lengths`**: Time series length(s) for which to compute the
+    cross mapping(s).
+
+## Summary keyword arguments
+- **`summarise`**: Should cross map skills be summarised for each time series length?
+    Default is `summarise = true`.
+- **`average_measure`**: Either `:median` or `:mean`. Default is `:median`.
+- **`uncertainty_measure`**: Either `:quantile` or `:std`. Default is `:quantile`.
+- **`quantiles`**: Compute uncertainty over quantile(s) if `uncertainty_measure`
+    is `:quantile`. Default is `[0.327, 0.673]`, roughly corresponding to 1s for
+    normally distributed data.
+
+## Keyword arguments to `crossmap`
+- **`dim`**: The dimension of the state space reconstruction (delay embedding)
+    constructed from the `response` series. Default is `dim = 3`.
+- **`τ`**: The embedding lag for the delay embedding constructed from `response`.
+    Default is `τ = 1`.
+- **`ν`**: The prediction lag to use when predicting scalar values of `driver`
+    fromthe delay embedding of `response`.
+    `ν > 0` are forward lags (causal; `driver`'s past influences `response`'s future),
+    and `ν < 0` are backwards lags (non-causal; `driver`'s' future influences
+    `response`'s past). Adjust the prediction lag if you
+    want to performed lagged ccm
+    [(Ye et al., 2015)](https://www.nature.com/articles/srep14750).
+    Default is `ν = 0`, as in
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079).
+    *Note: The sign of the lag `ν` is organized to conform with the conventions in
+    [TransferEntropy.jl](), and is opposite to the convention used in the
+    [`rEDM`](https://cran.r-project.org/web/packages/rEDM/index.html) package
+    ([Ye et al., 2016](https://cran.r-project.org/web/packages/rEDM/index.html)).*
+- **`libsize`**: Among how many delay embedding points should we sample time indices
+    and look for nearest neighbours at each cross mapping realization (of which there
+    are `n_reps`)?
+- **`n_reps`**: The number of times we draw a library of `libsize` points from the
+    delay embedding of `response` and try to predict `driver` values. Equivalently,
+    how many times do we cross map for this value of `libsize`?
+    Default is `n_reps = 100`.
+- **`replace`**: Sample delay embedding points with replacement? Default is `replace = true`.
+- **`exclusion_radius`**: How many temporal neighbors of the delay embedding
+    point `response_embedding(t)` to exclude when searching for neighbors to
+    determine weights for predicting the scalar point `driver(t + ν)`.
+    Default is `exclusion_radius = 0`.
+- **`which_is_surr`**: Which data series should be replaced by a surrogate
+    realization of the type given by `surr_type`? Must be one of the
+    following: `:response`, `:driver`, `:none`, `:both`.
+    Default is `:none`.
+- **`surr_func`**: A valid surrogate function from TimeseriesSurrogates.jl.
+- **`tree_type`**: The type of tree to build when looking for nearest neighbors.
+    Must be a tree type from NearestNeighbors.jl. For now, this is either
+    `BruteTree`, `KDTree` or `BallTree`.
+- **`distance_metric`**: An instance of a `Metric` from Distances.jl. `BallTree` and `BruteTree` work with any `Metric`.
+    `KDTree` only works with the axis aligned metrics `Euclidean`, `Chebyshev`,
+    `Minkowski` and `Cityblock`. Default is `metric = Euclidean()` *(note the instantiation of the metric)*.
+- **`correspondence_measure`**: The function that computes the correspondence
+    between actual values of `driver` and predicted values. Can be any
+    function returning a similarity measure between two vectors of values.
+    Default is `correspondence_measure = StatsBase.cor`, which returns values on ``[-1, 1]``.
+    In this case, any negative values are usually filtered out (interpreted as zero coupling) and
+    a value of ``1`` means perfect prediction.
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+    also proposes to use the root mean square deviation, for which a value of ``0`` would
+    be perfect prediction.
+
+## References
+Sugihara, George, et al. "Detecting causality in complex ecosystems."
+Science (2012): 1227079.
+[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+
+Ye, Hao, et al. "Distinguishing time-delayed causal interactions using convergent cross mapping." Scientific Reports 5 (2015): 14750.
+[https://www.nature.com/articles/srep14750](https://www.nature.com/articles/srep14750)
+
+Ye, H., et al. "rEDM: Applications of empirical dynamic modeling from time series." R Package Version 0.4 7 (2016).
+[https://cran.r-project.org/web/packages/rEDM/index.html](https://cran.r-project.org/web/packages/rEDM/index.html)
+"""
+function convergentcrossmap(driver,
+            response,
+            timeseries_lengths;
+            summarise::Bool = true,
+            average_measure::Symbol = :median,
+            uncertainty_measure::Symbol = :quantile,
+            quantiles = [0.327, 0.673],
+            kwargs...)
+
+    validate_average_measure(average_measure)
+    validate_uncertainty_measure(uncertainty_measure)
+    validate_output_selection(average_measure, uncertainty_measure, summarise)
+
+    if summarise
+        ccm_with_summary(driver,
+            response,
+            timeseries_lengths;
+            kwargs...)
+    else
+        ccm(driver,
+            response,
+            timeseries_lengths;
+            kwargs...)
+    end
+end

--- a/src/convergent_cross_mapping/crossmapping.jl
+++ b/src/convergent_cross_mapping/crossmapping.jl
@@ -1,0 +1,288 @@
+using StateSpaceReconstruction
+include("validate_input.jl")
+
+"""
+    predict_point!(predictions, i, driver_values, u, w, dists, dim)
+
+The prediction part of the convergent cross mapping algorithm.
+
+## Algorithm
+
+Consider the point in the delay embedding of `response` point with
+time index `i`. Denote the time indices of its nearest
+neighbors ``t_1, t_2, \\ldots, t_{dim+1}``. Denote the scalar values
+of `driver` at those time indices ``y_1, y_2, \\ldots, y_{dim+1}``.
+
+Given `distances` ``d_1, d_2, \\ldots, d_{dim+1}`` from the `i`-th
+point to its nearest neighbors, we compute the weights `w` from
+the cross mapping algorithm ([Sugihara et al, 2012; supplementary
+material, page 4](http://science.sciencemag.org/content/sci/suppl/2012/09/19/science.1227079.DC1/Sugihara.SM.pdf)). The weights `w` and coefficients `u` are stored in
+pre-allocated vectors.
+
+A prediction for the observation with time index `i` in the `driver`
+timeseries, call it ``\\hat{y}(i)``, is computed as the sum
+
+```math
+\\hat{y}(i) = \\sum_{j=1}^{dim+1} w_j y_j.
+```
+
+We store the prediction ``\\hat{y}(i)`` in position `i` of the pre-allocated vector
+`predictions`.
+
+
+## Arguments
+- **`predictions`**: A pre-allocated vector in which to store the
+    prediction for the scalar value of the `driver` series.
+- **`i`**: The time index of the point of the `driver` series being
+    predicted. The prediction is stored in `predictions[i]`.
+- **`driver_values`**: Let ``t_1, t_2, \\ldots, t_{dim + 1}`` be
+    the time indices of
+    the nearest neighbors to the delay embedding point with time
+    index `i`. `driver_values` contains the scalar values of the
+    `driver` series at those time indices.
+- **`u`**: A pre-allocated vector of length `dim + 1` that holds the
+    normalisation coefficients for computing the weights in the
+    cross mapping algorithm.
+- **`w`**: A pre-allocated vector of length `dim + 1` that holds
+    the computed weights for the cross mapping algorithm.
+- **`dists`**: The distances from delay embedding point with time index
+    `i` to its `dim + 1` nearest neighbors, in order of increasing
+    distances.
+- **`dim`**: The dimension of the delay embedding.
+
+## References
+Sugihara, George, et al. "Detecting causality in complex ecosystems."
+Science (2012): 1227079.
+[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+
+"""
+function predict_point!(predictions, i, driver_values, u, w, distances, dim)
+    if distances[1] == 0
+        @warn "The first distance is zero. Will yield division by zero"
+    end
+    for j in 1:(dim + 1)
+        u[j] = exp(-(distances[j]/distances[1]))
+    end
+    # The `predictions` vector is pre-allocated and `predictions[i]` may
+    # have a nonzero value if it has been visited in a previous iteration.
+    # Reset, so that we are always starting the prediction from zero.
+    predictions[i] = 0.0
+    for j in 1:(dim + 1)
+        #w[j] = u[j] / sum(u)
+        predictions[i] =+ sum((u[j] / sum(u)) .* driver_values)
+    end
+end
+
+
+function find_nearest!(nearest_idxs, nearest_dists, i, idxs, dists, dim, exclusion_radius)
+    if (2 * exclusion_radius + 2 + dim) > length(idxs[1])
+       throw(DomainError(exclusion_radius, "Too few points can be selected from `idxs=$idxs` with `dim=$dim` and `exclusion_radius=$exclusion_radius`."))
+    end
+
+    N = length(nearest_idxs)
+
+    for k = 1:N
+        # If exclusion_radius == 0, then skip the first
+        # point, because it is the distance to itself.
+        if exclusion_radius == 0
+            for j = 1:(dim + 1)
+                nearest_idxs[k][j] = idxs[k][j + 1]
+                nearest_dists[k][j] = dists[k][j + 1]
+            end
+        # Otherwise, find the nearest neighbors outside
+        # the temporal exclusion radius.
+        else
+            points_found = 0
+            # assume we have already checked a point, so that
+            # we skip the first neighbor (which is the point
+            # itself).
+            points_tried = 1
+            while points_found < (dim + 1)
+                if (idxs[k][points_tried + 1] < (i - exclusion_radius) ||
+                    idxs[k][points_tried + 1] > (i + exclusion_radius))
+                    nearest_idxs[k][points_found + 1] = idxs[k][points_tried + 1]
+                    nearest_dists[k][points_found + 1] = dists[k][points_tried + 1]
+                    points_found += 1
+                end
+                points_tried += 1
+            end
+        end
+    end
+end
+
+
+"""
+    crossmap(driver, response;
+        dim::Int = 3,
+        τ::Int = 1,
+        libsize::Int = 10,
+        replace::Bool = false,
+        n_reps::Int = 100,
+        surr_func::Function = randomshuffle,
+        which_is_surr::Symbol = :none,
+        exclusion_radius::Int = 0,
+        tree_type = NearestNeighbors.KDTree,
+        distance_metric = Distances.Euclidean(),
+        correspondence_measure = StatsBase.cor,
+        ν::Int = 0)
+
+## Algorithm
+Compute the cross mapping between a `driver` series and a `response` series.
+
+## Arguments
+- **`driver`**: The data series representing the putative driver process.
+- **`response`**: The data series representing the putative response process.
+- **`dim`**: The dimension of the state space reconstruction (delay embedding)
+    constructed from the `response` series. Default is `dim = 3`.
+- **`τ`**: The embedding lag for the delay embedding constructed from `response`.
+    Default is `τ = 1`.
+- **`ν`**: The prediction lag to use when predicting scalar values of `driver`
+    fromthe delay embedding of `response`.
+    `ν > 0` are forward lags (causal; `driver`'s past influences `response`'s future),
+    and `ν < 0` are backwards lags (non-causal; `driver`'s' future influences
+    `response`'s past). Adjust the prediction lag if you
+    want to performed lagged ccm
+    [(Ye et al., 2015)](https://www.nature.com/articles/srep14750).
+    Default is `ν = 0`, as in
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079).
+    *Note: The sign of the lag `ν` is organized to conform with the conventions in
+    [TransferEntropy.jl](), and is opposite to the convention used in the
+    [`rEDM`](https://cran.r-project.org/web/packages/rEDM/index.html) package
+    ([Ye et al., 2016](https://cran.r-project.org/web/packages/rEDM/index.html)).*
+- **`libsize`**: Among how many delay embedding points should we sample time indices
+    and look for nearest neighbours at each cross mapping realization (of which there
+    are `n_reps`)?
+- **`n_reps`**: The number of times we draw a library of `libsize` points from the
+    delay embedding of `response` and try to predict `driver` values. Equivalently,
+    how many times do we cross map for this value of `libsize`?
+    Default is `n_reps = 100`.
+- **`replace`**: Sample delay embedding points with replacement? Default is `replace = true`.
+- **`exclusion_radius`**: How many temporal neighbors of the delay embedding
+    point `response_embedding(t)` to exclude when searching for neighbors to
+    determine weights for predicting the scalar point `driver(t + ν)`.
+    Default is `exclusion_radius = 0`.
+- **`which_is_surr`**: Which data series should be replaced by a surrogate
+    realization of the type given by `surr_type`? Must be one of the
+    following: `:response`, `:driver`, `:none`, `:both`.
+    Default is `:none`.
+- **`surr_func`**: A valid surrogate function from TimeseriesSurrogates.jl.
+- **`tree_type`**: The type of tree to build when looking for nearest neighbors.
+    Must be a tree type from NearestNeighbors.jl. For now, this is either
+    `BruteTree`, `KDTree` or `BallTree`.
+- **`distance_metric`**: An instance of a `Metric` from Distances.jl. `BallTree` and `BruteTree` work with any `Metric`.
+    `KDTree` only works with the axis aligned metrics `Euclidean`, `Chebyshev`,
+    `Minkowski` and `Cityblock`. Default is `metric = Euclidean()` *(note the instantiation of the metric)*.
+- **`correspondence_measure`**: The function that computes the correspondence
+    between actual values of `driver` and predicted values. Can be any
+    function returning a similarity measure between two vectors of values.
+    Default is `correspondence_measure = StatsBase.cor`, which returns values on ``[-1, 1]``.
+    In this case, any negative values are usually filtered out (interpreted as zero coupling) and
+    a value of ``1`` means perfect prediction.
+    [Sugihara et al. (2012)](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+    also proposes to use the root mean square deviation, for which a value of ``0`` would
+    be perfect prediction.
+
+## References
+Sugihara, George, et al. "Detecting causality in complex ecosystems."
+Science (2012): 1227079.
+[http://science.sciencemag.org/content/early/2012/09/19/science.1227079](http://science.sciencemag.org/content/early/2012/09/19/science.1227079)
+
+Ye, Hao, et al. "Distinguishing time-delayed causal interactions using convergent cross mapping." Scientific Reports 5 (2015): 14750.
+[https://www.nature.com/articles/srep14750](https://www.nature.com/articles/srep14750)
+
+Ye, H., et al. "rEDM: Applications of empirical dynamic modeling from time series." R Package Version 0.4 7 (2016).
+[https://cran.r-project.org/web/packages/rEDM/index.html](https://cran.r-project.org/web/packages/rEDM/index.html)
+"""
+function crossmap(driver, response;
+            dim::Int = 3,
+            τ::Int = 1,
+            ν::Int = 0,
+            libsize::Int = length(driver) - dim*τ - abs(ν),
+            n_reps::Int = 100,
+            replace::Bool = true,
+            exclusion_radius::Int = 0,
+            jitter::Float64 = 1e-3,
+            which_is_surr::Symbol = :none,
+            surr_func::Function = randomshuffle,
+            tree_type = NearestNeighbors.KDTree,
+            distance_metric = Distances.Euclidean(),
+            correspondence_measure = StatsBase.cor)
+
+    points_available = length(response) - dim*τ
+    validate_exclusion_radius!(exclusion_radius, points_available)
+    validate_embedding_params(dim, τ, points_available)
+    validate_surr(which_is_surr, surr_func)
+    validate_libsize(libsize, driver, dim, τ, ν, replace)
+
+    if which_is_surr == :response
+        response = surr_func(response)
+    elseif which_is_surr == :driver
+        driver = surr_func(driver)
+    elseif which_is_surr == :both
+        driver = surr_func(driver)
+        response = surr_func(response)
+    end
+
+    ######################################################################
+    # Embedding and the nearest neighbor search.
+    # ----------------------------------------------------------
+    # All searches are done before the cross mapping repetitions,
+    # because this is computationally cheaper for all but the
+    # smallest library sizes and number of repetitions.
+    ######################################################################
+    embedding_lags = collect(1:-τ:-(τ*dim - 1))
+    embedding = StateSpaceReconstruction.Embeddings.embed([response], [1 for i in 1:dim], embedding_lags).points
+    n_embedding_pts = size(embedding, 2)
+
+    validate_embedding!(embedding, jitter)
+    tree = tree_type(embedding, distance_metric)
+
+    idxs, dists = knn(tree, embedding, dim + 2 + 2*exclusion_radius + 1, true)
+    nearest_idxs = [zeros(Int32, dim + 1) for i = 1:n_embedding_pts]
+    nearest_dists = [zeros(Float64, dim + 1) for i = 1:n_embedding_pts]
+
+    for i in 1:n_embedding_pts
+        find_nearest!(nearest_idxs, nearest_dists, i, idxs, dists, dim, exclusion_radius)
+    end
+
+    ######################################################################
+    # Cross mapping
+    ######################################################################
+    # Pre-allocate vectors to hold weights and coefficients, as well as
+    # the predictions, for the prediction part of the algorithm.
+    u = Vector{Float64}(undef, dim + 1)
+    w = Vector{Float64}(undef, dim + 1)
+    predictions =  zeros(Float64, libsize)
+
+    # Pre-allocate vector to hold the time indices of the library points
+    # we select at each cross map repetition (it is from these points
+    # predictions are made).
+    point_idxs = zeros(Int32, libsize)
+
+    # Pre-allocate vector to hold the correspondences between actual
+    # and predicted values of the driver time series.
+    correspondence = zeros(Float64, n_reps)
+
+    for k in 1:n_reps
+        if ν >= 0
+            sample!((1 + ν):n_embedding_pts, point_idxs, replace = replace)
+        else
+            sample!(1:(n_embedding_pts - abs(ν)), point_idxs, replace = replace)
+        end
+
+        # For every point selected at this repetition, make a prediction.
+        @inbounds for i in 1:length(point_idxs)
+            idx = point_idxs[i]
+            predict_point!(predictions, i, driver[nearest_idxs[idx]], u, w, nearest_dists[idx], dim)
+        end
+
+        correspondence[k] = correspondence_measure(predictions, driver[point_idxs .- ν])
+    end
+
+    return correspondence
+end
+
+export
+predict_point!,
+find_nearest!,
+crossmap

--- a/src/convergent_cross_mapping/validate_input.jl
+++ b/src/convergent_cross_mapping/validate_input.jl
@@ -67,9 +67,32 @@ function validate_surr(which_is_surr, surr_func)
 end
 
 
+function validate_uncertainty_measure(uncertainty_measure)
+    if uncertainty_measure ∉ [:quantile, :std, :none]
+        throw(DomainError(uncertainty_measure, "uncertainty_measure = $uncertainty_measure is invalid. Must be either :quantile, :std or :none."))
+    end
+end
+
+
+function validate_average_measure(average_measure)
+    if average_measure ∉ [:mean, :median, :none]
+        throw(DomainError(average_measure, "average_measure = $average_measure is invalid. Must be either :median, :mean or :none."))
+    end
+end
+
+
+function validate_output_selection(average_measure, uncertainty_measure, summarise)
+    if ((average_measure, uncertainty_measure) == (:none, :none)) && summarise
+        throw(ErrorException("Setting both average_measure and uncertainty_measure to :none while summarise = true will not produce output."))
+    end
+end
+
 export
 validate_surr,
 validate_libsize,
 validate_embedding!,
 validate_embedding_params,
-validate_exclusion_radius!
+validate_exclusion_radius!,
+validate_uncertainty_measure,
+validate_average_measure,
+validate_output_selection

--- a/test/crossmapping.jl
+++ b/test/crossmapping.jl
@@ -1,0 +1,75 @@
+@testset "Cross mapping" begin
+	@testset "Find nearest indices within exclusion radius" begin
+	    some_idxs = 1:21 |> collect
+	    some_dists = rand(length(some_idxs))
+	    d = 3
+	    exclusion_radius = 7
+	    dists = rand(length(some_idxs))
+	    idxs, dists = [some_idxs, some_idxs.+1], [some_dists, some_dists]
+	    libsize = length(some_idxs)
+	    pt_time_idx = 10
+	    nearest_idxs = [Vector{Int32}(undef, d + 1) for i = 1:2]
+	    nearest_dists = [Vector{Float64}(undef, d + 1) for i = 1:2]
+	    find_nearest!(nearest_idxs, nearest_dists, pt_time_idx, idxs, dists, d, exclusion_radius)
+	    @test nearest_idxs[1] == [2, 18, 19, 20]
+	    @test nearest_idxs[2] == [18, 19, 20, 21]
+
+	    # Too large exclusion radius
+	    @test_throws DomainError find_nearest!(nearest_idxs, nearest_dists, 12, idxs, dists, d, exclusion_radius + 10)
+	end
+
+	@testset "Prediction lags" begin
+	    x, y = rand(100), rand(100)
+	    crossmap(x, y, ν = 1)
+	    crossmap(x, y, ν = -1)
+	    crossmap(x, y, ν = 5)
+	    crossmap(x, y, ν = -5)
+	end
+
+	@testset "Embedding params" begin
+	    x, y = rand(100), rand(100)
+	    @test_throws DomainError crossmap(x, y, dim = -3)
+	    @test_throws DomainError crossmap(x, y, dim = 100, τ = 2)
+	    crossmap(x, y, dim = 3)
+	    crossmap(x, y, dim = 10, τ = 2)
+	end
+
+	@testset "Exclusion radii" begin
+	    x, y = rand(100), rand(100)
+	    [crossmap(x, y, exclusion_radius = i) for i in rand(1:25, 10)]
+	    #@test_throws DomainError crossmap(x, y, exclusion_radius = -1)
+	end
+
+	@testset "Replacements" begin
+	    x, y = rand(100), rand(100)
+	    crossmap(x, y, replace = false)
+	    crossmap(x, y, replace = true)
+	end
+
+	@testset "Surrogates" begin
+    x, y = rand(100), rand(100)
+	    @testset "Surrogate types" begin
+	        surrogate_funcs = [TimeseriesSurrogates.randomshuffle,
+	                            TimeseriesSurrogates.randomphases,
+	                            TimeseriesSurrogates.randomamplitudes,
+	                            TimeseriesSurrogates.aaft,
+	                            TimeseriesSurrogates.iaaft]
+	        [crossmap(x, y, surr_func = surr_func) for surr_func in surrogate_funcs]
+	        @test_throws DomainError crossmap(x, y, surr_func = StatsBase.cor)
+	    end
+	    @testset "Which is surrogated" begin
+	        which_surr = [:none, :both, :driver, :response]
+	        [crossmap(x, y, which_is_surr = surr) for surr in which_surr]
+	        @test_throws DomainError crossmap(x, y, which_is_surr = :aksdj)
+	    end
+	end
+
+	@testset "Correspondence measures" begin
+	    @testset "$i" for i in 1:100
+	        x, y = rand(100), rand(100)
+	        @test all(crossmap(x, y, correspondence_measure = StatsBase.rmsd) .>= 0)
+	        @test all([-1 <= x <= 1 for x in crossmap(x, y, correspondence_measure = StatsBase.cor)])
+	    end
+	end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ using NearestNeighbors
 using TimeseriesSurrogates
 using StateSpaceReconstruction
 
+include("crossmapping.jl")
 include("convergentcrossmapping.jl")


### PR DESCRIPTION
Added convergent cross mapping functions, including input validation and tests. Renamed old `convergentcrossmap` functions to `crossmap` because the old function did not iterate over varying time series length. Addresses #5.